### PR TITLE
パッケージオプションを listings に渡すように変更

### DIFF
--- a/plistings.sty
+++ b/plistings.sty
@@ -5,6 +5,10 @@
 
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{plistings}[2015/12/07 v0.10 Japanese support of listings package]
+
+%%%%%%%% Package options
+\DeclareOption*{\PassOptionsToPackage{\CurrentOption}{listings}}
+\ProcessOptions\relax
 \RequirePackage{listings,etoolbox}
 
 %%%%%%%% Japanese support


### PR DESCRIPTION
変更は表題の通りです．

現状 listings パッケージにオプションを渡すには plistings 読み込み前に

```tex
\usepackage[<options>]{listings}
```

をする必要があり冗長な感じがするので，副作用がない限り個人的には便利だと思います．

副作用ですが，[clsguide.pdf](http://mirror.ctan.org/macros/latex/doc/clsguide.pdf) のサンプルほぼそのままのコードなので，まずないと思われます．テストを書いたわけではありませんが，私の環境では期待通り動作しています．